### PR TITLE
Redirect to employee view of KR form

### DIFF
--- a/lib/husky_musher/tests/lead_dawgs.py
+++ b/lib/husky_musher/tests/lead_dawgs.py
@@ -8,7 +8,6 @@ from utils.redcap import *
 REDCAP_RECORD = {
     'record_id': '-1',
 }
-PROJECT = Project(REDCAP_API_URL, REDCAP_API_TOKEN, PROJECT_ID)
 
 class TestLeadDawgs0(unittest.TestCase):
     """

--- a/lib/husky_musher/tests/lead_dawgs.py
+++ b/lib/husky_musher/tests/lead_dawgs.py
@@ -5,6 +5,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from utils.redcap import *
 
+REDCAP_RECORD = {
+    'record_id': '-1',
+}
+PROJECT = Project(REDCAP_API_URL, REDCAP_API_TOKEN, PROJECT_ID)
 
 class TestLeadDawgs0(unittest.TestCase):
     """
@@ -34,6 +38,14 @@ class TestLeadDawgs0(unittest.TestCase):
 
     def test_need_to_create_new_kr_instance(self):
         self.assertFalse(need_to_create_new_kr_instance(self.instances))
+
+    def test_kiosk_registration_link(self):
+        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+            f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
+            f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
+            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&instance={get_todays_repeat_instance()}"
+        )
 
 
 class TestLeadDawgs1(unittest.TestCase):
@@ -86,6 +98,13 @@ class TestLeadDawgs1(unittest.TestCase):
     def test_need_to_create_new_kr_instance(self):
         self.assertTrue(need_to_create_new_kr_instance(self.instances))
 
+    def test_kiosk_registration_link(self):
+        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+            f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
+            f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
+            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&instance={self.instances['target']}"
+        )
 
 class TestLeadDawgs2(unittest.TestCase):
     """
@@ -141,6 +160,13 @@ class TestLeadDawgs2(unittest.TestCase):
     def test_incomplete_kr_instance_is_not_none(self):
         self.assertTrue(self.instances['incomplete_kr'] is not None)
 
+    def test_kiosk_registration_link(self):
+        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+            f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
+            f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
+            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&instance={self.instances['incomplete_kr']}"
+        )
 
 class TestLeadDawgs3(unittest.TestCase):
     """
@@ -193,6 +219,14 @@ class TestLeadDawgs3(unittest.TestCase):
     def test_need_to_create_new_kr_instance(self):
         self.assertFalse(need_to_create_new_kr_instance(self.instances))
 
+    def test_kiosk_registration_link(self):
+        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+            f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
+            f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
+            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&instance={get_todays_repeat_instance()}"
+        )
+
 
 class TestLeadDawgs4(unittest.TestCase):
     """
@@ -243,3 +277,11 @@ class TestLeadDawgs4(unittest.TestCase):
 
     def test_need_to_create_new_kr_instance(self):
         self.assertFalse(need_to_create_new_kr_instance(self.instances))
+
+    def test_kiosk_registration_link(self):
+        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+            f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
+            f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
+            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&instance={get_todays_repeat_instance()}"
+        )

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -4,11 +4,14 @@ import requests
 from flask import request
 from datetime import datetime, timedelta
 from typing import Dict, Optional, List
-from id3c.cli.redcap import is_complete
+from urllib.parse import urlencode, urljoin
+from id3c.cli.redcap import is_complete, Project
 
 
 REDCAP_API_TOKEN = os.environ['REDCAP_API_TOKEN']
 REDCAP_API_URL = os.environ['REDCAP_API_URL']
+PROJECT_ID = 23854
+EVENT_ID = 742155
 STUDY_START_DATE = datetime(2020, 9, 24) # Study start date of 2020-09-24
 
 # These values in REDCap must be imported as their raw codes, not their label,
@@ -521,30 +524,40 @@ def kiosk_registration_link(redcap_record: dict, instances: Dict[str, int]) -> s
     appropriate survey link to the correct instance of a Kiosk Registration
     instrument according to the pre-determined logic flow.
     """
-    record_id = redcap_record['record_id']
-    event = 'encounter_arm_1'
-    instrument = 'kiosk_registration_4c7f'
     incomplete_kr_instance = instances['incomplete_kr']
 
     if need_to_create_new_td_for_today(instances):
         # Create TD instance based on # of days since project start.
         create_new_testing_determination(redcap_record)
-
-        # Generate a link to the KR, and then redirect.
-        survey_link = generate_survey_link(record_id, event, instrument,
-            get_todays_repeat_instance())
+        instance = get_todays_repeat_instance()
 
     elif need_to_create_new_kr_instance(instances):
-        # Generate a link to the target instance, and then redirect.
-        survey_link = generate_survey_link(record_id, event, instrument,
-            instances['target'])
+        instance = instances['target']
 
     elif incomplete_kr_instance is not None:
-        # Generate a link to the existing KR that is incomplete, and then redirect.
-        survey_link = generate_survey_link(record_id, event, instrument,
-            incomplete_kr_instance)
+        instance = incomplete_kr_instance
 
     else:
         raise Exception("Logic error when generating survey links.")
 
-    return survey_link
+    return generate_redcap_link(redcap_record, instance)
+
+
+def generate_redcap_link(redcap_record: dict, instance: int):
+    """
+    Given a *redcap_record*, generate a link to the internal REDCap portal's
+    Kiosk Registration form for the record's given REDCap repeat *instance*.
+    """
+    project = Project(REDCAP_API_URL, REDCAP_API_TOKEN, PROJECT_ID)
+
+    query = urlencode({
+        'pid': project.id,
+        'id': redcap_record['record_id'],
+        'arm': 'encounter_arm_1',
+        'event_id': EVENT_ID,
+        'page': 'kiosk_registration_4c7f',
+        'instance': instance,
+    })
+
+    return urljoin(project.base_url,
+        f"redcap_v{project.redcap_version}/DataEntry/index.php?{query}")

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -14,6 +14,22 @@ PROJECT_ID = 23854
 EVENT_ID = 742155
 STUDY_START_DATE = datetime(2020, 9, 24) # Study start date of 2020-09-24
 
+# TODO - Since creating PROJECT has side effects (network requests), we should
+# # probably define it lazily (e.g. with `global PROJECT` and then assigning it
+# the Project object `if not PROJECT`.
+#
+# During development, I could not get unit tests to run without running into a
+# NameError saying PROJECT is not defined.
+# Tom left some helpful feedback in a PR comment:
+# > I suspect this is because the tests as-is access PROJECT directly but it was
+# > only initialized with a value on the first call to generate_redcap_link().
+# > The references to PROJECT in the tests are resolved before that first call
+# > happens, so PROJECT was unset.
+#
+# It would be nice to investigate further how to define PROJECT lazily in
+# coordination with unit tests.
+#
+# -kfay, 23 October 2020
 PROJECT = Project(REDCAP_API_URL, REDCAP_API_TOKEN, PROJECT_ID)
 
 # These values in REDCap must be imported as their raw codes, not their label,

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -14,6 +14,8 @@ PROJECT_ID = 23854
 EVENT_ID = 742155
 STUDY_START_DATE = datetime(2020, 9, 24) # Study start date of 2020-09-24
 
+PROJECT = Project(REDCAP_API_URL, REDCAP_API_TOKEN, PROJECT_ID)
+
 # These values in REDCap must be imported as their raw codes, not their label,
 # else we get a 400 Client Error from REDCap when POSTing.
 YES = '1'
@@ -520,9 +522,9 @@ def need_to_create_new_kr_instance(instances: Dict[str, int]) -> bool:
 
 def kiosk_registration_link(redcap_record: dict, instances: Dict[str, int]) -> str:
     """
-    Given information about recent *instances* of a REDCap record, returns an
-    appropriate survey link to the correct instance of a Kiosk Registration
-    instrument according to the pre-determined logic flow.
+    Given information about recent *instances* of a *redcap_record*, returns an
+    internal link to the correct instance of a Kiosk Registration instrument
+    according to the pre-determined logic flow.
     """
     incomplete_kr_instance = instances['incomplete_kr']
 
@@ -548,10 +550,8 @@ def generate_redcap_link(redcap_record: dict, instance: int):
     Given a *redcap_record*, generate a link to the internal REDCap portal's
     Kiosk Registration form for the record's given REDCap repeat *instance*.
     """
-    project = Project(REDCAP_API_URL, REDCAP_API_TOKEN, PROJECT_ID)
-
     query = urlencode({
-        'pid': project.id,
+        'pid': PROJECT.id,
         'id': redcap_record['record_id'],
         'arm': 'encounter_arm_1',
         'event_id': EVENT_ID,
@@ -559,5 +559,5 @@ def generate_redcap_link(redcap_record: dict, instance: int):
         'instance': instance,
     })
 
-    return urljoin(project.base_url,
-        f"redcap_v{project.redcap_version}/DataEntry/index.php?{query}")
+    return urljoin(PROJECT.base_url,
+        f"redcap_v{PROJECT.redcap_version}/DataEntry/index.php?{query}")


### PR DESCRIPTION
Instead of generating the PT-facing survey link for the kiosk
registration form, drop the Lead Dawgs kiosk staff user inside of of the
REDCap employee-side of the Kiosk Registration form. This view has more
information about the current record which will better allow the kiosk
staff to verify that they're in the right place.