### PR TITLE
Operator bug

### DIFF
--- a/lib/husky_musher/tests/lead_dawgs.py
+++ b/lib/husky_musher/tests/lead_dawgs.py
@@ -192,3 +192,54 @@ class TestLeadDawgs3(unittest.TestCase):
 
     def test_need_to_create_new_kr_instance(self):
         self.assertFalse(need_to_create_new_kr_instance(self.instances))
+
+
+class TestLeadDawgs4(unittest.TestCase):
+    """
+    A test case where a PT's testing was never triggered but they have a
+    complete TOS and a complete KR in the past week.
+    """
+    def setUp(self):
+        self.recent_encounters = [
+            {
+                'redcap_repeat_instance': str(one_week_ago() + 1),
+                'testing_determination_complete': '2',
+                'testing_trigger': 'No',
+                'test_order_survey_complete': '',
+                'kiosk_registration_4c7f_complete': ''
+            }, {
+                'redcap_repeat_instance': str(one_week_ago() + 2),
+                'testing_determination_complete': '',
+                'testing_trigger': '',
+                'test_order_survey_complete': '',
+                'kiosk_registration_4c7f_complete': '2'
+            }, {
+                'redcap_repeat_instance': str(one_week_ago() + 3),
+                'testing_determination_complete': '',
+                'testing_trigger': '',
+                'test_order_survey_complete': '2',
+                'kiosk_registration_4c7f_complete': ''
+            }
+        ]
+        self.instances = dict()
+        self.instances['target'] = target = max_instance_testing_triggered(self.recent_encounters)
+        self.instances['complete_tos'] = max_instance('test_order_survey',
+            self.recent_encounters, since=target)
+        self.instances['complete_kr'] = max_instance('kiosk_registration_4c7f',
+            self.recent_encounters, since=target)
+        self.instances['incomplete_kr'] = max_instance('kiosk_registration_4c7f',
+            self.recent_encounters, since=target, complete=False)
+
+    def test_instances(self):
+        self.assertEqual(self.instances, {
+            'target': None,
+            'complete_tos': one_week_ago() + 3,
+            'complete_kr': one_week_ago() + 2,
+            'incomplete_kr': None,
+        })
+
+    def test_need_to_create_new_td_for_today(self):
+        self.assertTrue(need_to_create_new_td_for_today(self.instances))
+
+    def test_need_to_create_new_kr_instance(self):
+        self.assertFalse(need_to_create_new_kr_instance(self.instances))

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -285,10 +285,18 @@ def max_instance(instrument: str, redcap_record: List[dict], since: int,
     events_instrument_complete = [
         encounter
         for encounter in redcap_record
-        if int(encounter['redcap_repeat_instance']) >= since
-        and encounter[f"{instrument}_complete"] != ''
+        if encounter[f"{instrument}_complete"] != ''
         and is_complete(instrument, encounter) == complete
     ]
+
+    # Filter since the latest instance where testing was triggered.
+    # If no instance exists, do not filter. Note: at this point in the code, we
+    # already are only considering instances in the past week.
+    if since is not None:
+        events_instrument_complete = list(filter(
+            lambda encounter: int(encounter['redcap_repeat_instance']) >= since,
+            events_instrument_complete
+        ))
 
     if not events_instrument_complete:
         return None

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -197,8 +197,14 @@ def fetch_encounter_events_past_week(redcap_record: dict) -> List[dict]:
     response.raise_for_status()
 
     encounters = response.json()
-    one_week_ago = get_todays_repeat_instance() - 7
-    return [ e for e in encounters if e['redcap_repeat_instance'] >= one_week_ago ]
+    return [ e for e in encounters if e['redcap_repeat_instance'] >= one_week_ago() ]
+
+
+def one_week_ago() -> int:
+    """
+    Return the REDCap instance instance currently representing one week ago.
+    """
+    return get_todays_repeat_instance() - 7
 
 
 def max_instance_testing_triggered(redcap_record: List[dict]) -> Optional[int]:


### PR DESCRIPTION
Fixes a bug where we have a complete TOS or KR instance but no testing triggered which resulted in a comparison of `>=` between 'int' and 'NoneType'.