### PR TITLE
Add new test case for multiple tests in same week

### DIFF
--- a/lib/husky_musher/tests/lead_dawgs.py
+++ b/lib/husky_musher/tests/lead_dawgs.py
@@ -284,3 +284,56 @@ class TestLeadDawgs4(unittest.TestCase):
             f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
             f"&instance={get_todays_repeat_instance()}"
         )
+
+
+class TestLeadDawgs5(unittest.TestCase):
+    """
+    A test case where a PT received a mail test kit and was selected again for
+    kiosk testing within the same week.
+    """
+    def setUp(self):
+        self.recent_encounters = [
+            {
+                'redcap_repeat_instance': str(one_week_ago() + 1),
+                'testing_determination_complete': '2',
+                'testing_trigger': 'Yes',
+                'test_order_survey_complete': '2',
+                'kiosk_registration_4c7f_complete': ''
+            }, {
+                'redcap_repeat_instance': str(one_week_ago() + 2),
+                'testing_determination_complete': '2',
+                'testing_trigger': 'Yes',
+                'test_order_survey_complete': '',
+                'kiosk_registration_4c7f_complete': ''
+            },
+        ]
+        self.instances = dict()
+        self.instances['target'] = target = max_instance_testing_triggered(self.recent_encounters)
+        self.instances['complete_tos'] = max_instance('test_order_survey',
+            self.recent_encounters, since=target)
+        self.instances['complete_kr'] = max_instance('kiosk_registration_4c7f',
+            self.recent_encounters, since=target)
+        self.instances['incomplete_kr'] = max_instance('kiosk_registration_4c7f',
+            self.recent_encounters, since=target, complete=False)
+
+    def test_instances(self):
+        self.assertEqual(self.instances, {
+            'target': one_week_ago() + 2,
+            'complete_tos': None,
+            'complete_kr': None,
+            'incomplete_kr': None,
+        })
+
+    def test_need_to_create_new_td_for_today(self):
+        self.assertFalse(need_to_create_new_td_for_today(self.instances))
+
+    def test_need_to_create_new_kr_instance(self):
+        self.assertTrue(need_to_create_new_kr_instance(self.instances))
+
+    def test_kiosk_registration_link(self):
+        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+            f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
+            f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
+            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&instance={one_week_ago() + 2}"
+        )


### PR DESCRIPTION
Add a new unit test to make sure we're pulling up the correct target
KR instance for a PT who had a mail test kit ordered within the same
week. The motivation for adding this test case comes from reports of a
possible bug in the Lead Dawgs logic, but the test case passes.