### PR TITLE
Use datetime for testing_date

### DIFF
--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -440,7 +440,7 @@ def create_new_testing_determination(redcap_record: dict):
         'redcap_repeat_instance': str(get_todays_repeat_instance()),
         'testing_trigger': YES,
         'testing_type': KIOSK_WALK_IN,
-        'testing_date': str(datetime.today().date()),
+        'testing_date': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         'testing_determination_internal_complete': COMPLETE,
     }]
 


### PR DESCRIPTION
In REDCap, the testing_date field is now configured to accept
datetime values. The Offer job is setting this as a datetime, so
change Lead Dawgs to do the same.