### PR TITLE
Update with new HCT REDCap server URL and project

### DIFF
--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -10,19 +10,20 @@ from id3c.cli.redcap import is_complete, Project
 from diskcache import FanoutCache
 
 
-REDCAP_API_URL = "https://redcap.iths.org/api/"
 DEVELOPMENT_MODE = os.environ.get("FLASK_ENV", "production") == "development"
 
 if DEVELOPMENT_MODE:
     # TESTING 2: Husky Coronavirus Testing
+    REDCAP_API_URL = "https://redcap.iths.org/api/"
     PROJECT_ID = 24515
     EVENT_ID = 743558
+    STUDY_START_DATE = datetime(2020, 9, 24) # Study start date of 2020-09-24
 else:
-    # Husky Coronavirus Testing
-    PROJECT_ID = 23854
-    EVENT_ID = 742155
-
-STUDY_START_DATE = datetime(2020, 9, 24) # Study start date of 2020-09-24
+    # Husky Coronavirus Testing 2021-2022
+    REDCAP_API_URL = "https://hct.redcap.rit.uw.edu/api/"
+    PROJECT_ID = 45
+    EVENT_ID = 129
+    STUDY_START_DATE = datetime(2021, 7, 14) # TODO - Before deploying, change to actual date when project is moved to production
 
 
 # TODO - Since creating PROJECT has side effects (network requests), we should

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -23,7 +23,7 @@ else:
     REDCAP_API_URL = os.environ["HCT_REDCAP_API_URL"]  # HCT REDCap server for production
     PROJECT_ID = 45
     EVENT_ID = 129
-    STUDY_START_DATE = datetime(2021, 7, 14) # TODO - Before deploying, change to actual date when project is moved to production
+    STUDY_START_DATE = datetime(2021, 9, 9) # Date testing opened on new HCT redcap server
 
 
 # TODO - Since creating PROJECT has side effects (network requests), we should

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -14,13 +14,13 @@ DEVELOPMENT_MODE = os.environ.get("FLASK_ENV", "production") == "development"
 
 if DEVELOPMENT_MODE:
     # TESTING 2: Husky Coronavirus Testing
-    REDCAP_API_URL = "https://redcap.iths.org/api/"
+    REDCAP_API_URL = os.environ["REDCAP_API_URL"]  # ITHS REDCap server for development/testing
     PROJECT_ID = 24515
     EVENT_ID = 743558
     STUDY_START_DATE = datetime(2020, 9, 24) # Study start date of 2020-09-24
 else:
     # Husky Coronavirus Testing 2021-2022
-    REDCAP_API_URL = "https://hct.redcap.rit.uw.edu/api/"
+    REDCAP_API_URL = os.environ["HCT_REDCAP_API_URL"]  # HCT REDCap server for production
     PROJECT_ID = 45
     EVENT_ID = 129
     STUDY_START_DATE = datetime(2021, 7, 14) # TODO - Before deploying, change to actual date when project is moved to production


### PR DESCRIPTION
Switching to new REDCap server for HCT 2021-2022. Husky Musher will
continue to use ITHS REDCap server for HCT development/test project, and
will use the new HCT REDCap server and HCT 2021-2022 project in production.

API URLs are hardcoded here instead of using environment variables for reasons
explained in a prior commit d04cf0c6ca4cca82f99178020c097aafeabebf6c, when the environment variable was removed
from the code. Until I have a better understanding of the reasoning there, I am keeping it
that way rather than reverting it.

One additional change is required prior to deploying, in `/lib/husky_musher/utils/redcap.py`
the `STUDY_START_DATE` should be updated to the date that the REDCap project changes to
production mode.