### PR TITLE
Require timestamp when linking to incomplete KR instance

### DIFF
--- a/lib/husky_musher/app.py
+++ b/lib/husky_musher/app.py
@@ -122,7 +122,7 @@ def lookup():
     =========
     PT = participant
     TD = Testing Determination instrument
-    TOS = Test Order Survey insrument
+    TOS = Test Order Survey instrument
     KR = Kiosk Registration instrument
     """
     netid = request.form['netid'].lower().strip()

--- a/lib/husky_musher/app.py
+++ b/lib/husky_musher/app.py
@@ -154,7 +154,7 @@ def lookup():
     instances['complete_kr'] = max_instance('kiosk_registration_4c7f', recent_encounters,
         since=instances['target'])
     instances['incomplete_kr'] = max_instance('kiosk_registration_4c7f', recent_encounters,
-        since=instances['target'], complete=False)
+        since=instances['target'], complete=False, required_field='nasal_swab_q')
 
     if instances['complete_tos'] == get_todays_repeat_instance():
         # We won't test this PT twice in one day

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -303,7 +303,7 @@ def max_instance(instrument: str, redcap_record: List[dict], since: int,
     completed instances, and False filters only for incomplete or unverified
     instances). The default value for *complete* is True.
 
-    Returns None if no completed insrument is found.
+    Returns None if no completed instrument is found.
 
     >>> max_instance('kiosk_registration_4c7f', [ \
         {'redcap_repeat_instance': '1', 'kiosk_registration_4c7f_complete': '2'}], \
@@ -514,7 +514,7 @@ def need_to_create_new_td_for_today(instances: Dict[str, int]) -> bool:
     given *target_instance*.
 
     *complete_kr_instance* is a KR instance number marked complete on or after the
-    given *target_intance*.
+    given *target_instance*.
 
     >>> need_to_create_new_td_for_today({'target': None, 'complete_tos': 1, 'complete_kr': 1})
     True
@@ -570,7 +570,7 @@ def need_to_create_new_kr_instance(instances: Dict[str, int]) -> bool:
     given *target_instance*.
 
     *complete_kr_instance* is a KR instance number marked complete on or after the
-    given *target_intance*.
+    given *target_instance*.
 
     >>> need_to_create_new_kr_instance({'target': None, 'complete_tos': 1, 'complete_kr': 1, 'incomplete_kr': None})
     False

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -234,7 +234,7 @@ def fetch_encounter_events_past_week(redcap_record: dict) -> List[dict]:
     """
     fields = [
         'record_id', 'testing_trigger', 'testing_determination_complete',
-        'kiosk_registration_4c7f_complete', 'test_order_survey_complete'
+        'kiosk_registration_4c7f_complete', 'test_order_survey_complete', 'nasal_swab_q'
     ]
     # Unfortunately, despite its appearance in the returned response from REDCap,
     # `redcap_repeat_instance` is not a field we can query by when exporting
@@ -295,7 +295,7 @@ def max_instance_testing_triggered(redcap_record: List[dict]) -> Optional[int]:
 
 
 def max_instance(instrument: str, redcap_record: List[dict], since: int,
-    complete: bool=True) -> Optional[int]:
+    complete: bool=True, required_field: str='') -> Optional[int]:
     """
     Returns the most recent instance number in a *redcap_record* on or after the
     given filter instance *since*. Filters also by events with an *instrument*
@@ -349,12 +349,41 @@ def max_instance(instrument: str, redcap_record: List[dict], since: int,
         {'redcap_repeat_instance': '2', 'test_order_survey_complete': '', \
             'kiosk_registration_4c7f_complete': '2'}], \
         since=0)
+
+    >>> max_instance('kiosk_registration_4c7f', [ \
+        {'redcap_repeat_instance': '1', 'kiosk_registration_4c7f_complete': '2', 'nasal_swab_q': ''}, \
+        {'redcap_repeat_instance': '2', 'kiosk_registration_4c7f_complete': '2', 'nasal_swab_q': ''}, \
+        {'redcap_repeat_instance': '3', 'kiosk_registration_4c7f_complete': '0', 'nasal_swab_q': ''}], \
+        since=1, complete=False, required_field='nasal_swab_q')
+
+    >>> max_instance('kiosk_registration_4c7f', [ \
+        {'redcap_repeat_instance': '1', 'kiosk_registration_4c7f_complete': '2', 'nasal_swab_q': ''}, \
+        {'redcap_repeat_instance': '2', 'kiosk_registration_4c7f_complete': '2', 'nasal_swab_q': '2021-09-10'}, \
+        {'redcap_repeat_instance': '3', 'kiosk_registration_4c7f_complete': '0', 'nasal_swab_q': '2021-09-11'}], \
+        since=1, complete=False, required_field='nasal_swab_q')
+    3
+
+    >>> max_instance('kiosk_registration_4c7f', [ \
+        {'redcap_repeat_instance': '1', 'kiosk_registration_4c7f_complete': '2', 'nasal_swab_q': '2021-09-09'}, \
+        {'redcap_repeat_instance': '2', 'kiosk_registration_4c7f_complete': '2', 'nasal_swab_q': ''}, \
+        {'redcap_repeat_instance': '3', 'kiosk_registration_4c7f_complete': '0', 'nasal_swab_q': '2021-09-11'}], \
+        since=1, required_field='nasal_swab_q')
+    1
+
+    >>> max_instance('kiosk_registration_4c7f', [ \
+        {'redcap_repeat_instance': '1', 'kiosk_registration_4c7f_complete': '2', 'nasal_swab_q': '2021-09-09'}, \
+        {'redcap_repeat_instance': '2', 'kiosk_registration_4c7f_complete': '2', 'nasal_swab_q': '2021-09-10'}, \
+        {'redcap_repeat_instance': '3', 'kiosk_registration_4c7f_complete': '0', 'nasal_swab_q': '2021-09-11'}], \
+        since=1, required_field='nasal_swab_q')
+    2
+
     """
     events_instrument_complete = [
         encounter
         for encounter in redcap_record
         if encounter[f"{instrument}_complete"] != ''
         and is_complete(instrument, encounter) == complete
+        and (not required_field or encounter[required_field] != '')
     ]
 
     # Filter since the latest instance where testing was triggered.


### PR DESCRIPTION
Originally, musher was designed to link into incomplete KR forms if
they existed, to handle the case of someone starting to register at the
kiosk, and partially filled out without being saved as complete. This
way, we would link the kiosk staff back into that incomplete kiosk
registration so it could be completed.

However, this doesn't account for certain behavior in RECCap, namely,
that incomplete KR forms are getting created as a byproduct of a repeat
instance getting created with any other instruments. It appears that
when REDCap creates a repeat instance for another instrument, for
example, a daily attestation, any forms in that repeat instance event
with calculated variables get created and those calculated variables
get values set.

These REDCap created forms that exist but aren't really partially
complete from a human user will still have kiosk_registration_4c7f='0'
instead of ''. To account for these, and ignore these when looking for
the correct instance to link to, let's add the concept of a required
field for the encounter to be considered.

For kiosk registrations, we'll use the timestamp field nasal_swab_q,
and enforce that to exist for us to consider linking into an existing
KR as partially complete. This way we can ignore the REDCap created
forms with just calculated variables.