### PR TITLE
Add timeout and check response content-type for requests to REDCap server

### DIFF
--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -11,6 +11,7 @@ from diskcache import FanoutCache
 
 
 DEVELOPMENT_MODE = os.environ.get("FLASK_ENV", "production") == "development"
+TIMEOUT = 30
 
 if DEVELOPMENT_MODE:
     # TESTING 2: Husky Coronavirus Testing
@@ -110,7 +111,7 @@ def fetch_participant(user_info: dict) -> Optional[Dict[str, str]]:
                 'returnFormat': 'json'
             }
 
-            response = requests.post(PROJECT.api_url, data=data)
+            response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
             response.raise_for_status()
 
             records = response.json()
@@ -150,7 +151,7 @@ def register_participant(user_info: dict) -> str:
         'returnContent': 'ids',
         'returnFormat': 'json'
     }
-    response = requests.post(PROJECT.api_url, data=data)
+    response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
     return response.json()[0]
 
@@ -176,7 +177,7 @@ def generate_survey_link(record_id: str, event: str, instrument: str, instance: 
     if instance:
         data['repeat_instance'] = str(instance)
 
-    response = requests.post(PROJECT.api_url, data=data)
+    response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
     return response.text
 
@@ -261,7 +262,7 @@ def fetch_encounter_events_past_week(redcap_record: dict) -> List[dict]:
         'returnFormat': 'json'
     }
 
-    response = requests.post(PROJECT.api_url, data=data)
+    response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
 
     encounters = response.json()
@@ -486,7 +487,7 @@ def create_new_testing_determination(redcap_record: dict):
         'returnFormat': 'json'
     }
 
-    response = requests.post(PROJECT.api_url, data=data)
+    response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
 
     assert len(response.json()) == 1, \

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -114,6 +114,9 @@ def fetch_participant(user_info: dict) -> Optional[Dict[str, str]]:
             response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
             response.raise_for_status()
 
+            assert 'application/json' in response.headers.get('Content-Type'), "Unexpected content type " \
+                f"≪{response.headers.get('Content-Type')}≫, expected ≪application/json≫."
+
             records = response.json()
 
             if len(records) == 0:
@@ -153,8 +156,15 @@ def register_participant(user_info: dict) -> str:
     }
     response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
-    return response.json()[0]
+    
+    assert 'application/json' in response.headers.get('Content-Type'), "Unexpected content type " \
+        f"≪{response.headers.get('Content-Type')}≫, expected ≪application/json≫."
 
+    records = response.json()
+
+    assert len(records) == 1, f"{len(records)} records returned, expected 1."
+
+    return records[0]
 
 @metric_redcap_request_seconds()
 def generate_survey_link(record_id: str, event: str, instrument: str, instance: int = None) -> str:
@@ -179,6 +189,10 @@ def generate_survey_link(record_id: str, event: str, instrument: str, instance: 
 
     response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
+
+    assert 'text/html' in response.headers.get('Content-Type'), "Unexpected content type " \
+        f"≪{response.headers.get('Content-Type')}≫, expected ≪text/html≫."
+
     return response.text
 
 
@@ -264,6 +278,9 @@ def fetch_encounter_events_past_week(redcap_record: dict) -> List[dict]:
 
     response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
+
+    assert 'application/json' in response.headers.get('Content-Type'), "Unexpected content type " \
+        f"≪{response.headers.get('Content-Type')}≫, expected ≪application/json≫."
 
     encounters = response.json()
     return [ e for e in encounters if e['redcap_repeat_instance'] >= one_week_ago() ]
@@ -489,6 +506,9 @@ def create_new_testing_determination(redcap_record: dict):
 
     response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
+
+    assert 'application/json' in response.headers.get('Content-Type'), "Unexpected content type " \
+        f"≪{response.headers.get('Content-Type')}≫, expected ≪application/json≫."
 
     assert len(response.json()) == 1, \
         f"REDCap updated {len(response.json())} records, expected 1."


### PR DESCRIPTION
Currently there is no timeout in place for these requests, so if the
REDCap server is having issues the requests can hang indefinitely and
cause number of available workers to drop to zero. By setting a timeout
the user will be redirected to the error page `something_went_wrong.html`.

Also adding additional checks for the content-type of the response, which
should be `application/json` when records are returned, and to confirm the
number of records returned for a newly registered participant is 1.