### PR TITLE
Add GitHub Actions for Husky Musher

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: python=${{ matrix.python }} os=${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-18.04
+        python:
+          - 3.9
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Upgrade Python toolchain
+        run: python3 -m pip install --upgrade pip setuptools wheel
+
+      - name: Install Pipenv
+        run: python3 -m pip install pipenv
+
+      - name: Install Dependencies
+        run: pipenv sync --dev
+
+      - name: Run doctest
+        run: pipenv run python3 -m doctest lib/husky_musher/utils/*
+
+      - name: Run unittest
+        run: pipenv run python -m unittest lib/husky_musher/tests/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on:
   - push
   - pull_request
 
+env:
+  REDCAP_API_URL: 'https://dummy.redcap.url/api'
+  FLASK_ENV: development
+
 jobs:
   test:
     name: python=${{ matrix.python }} os=${{ matrix.os }}
@@ -29,9 +33,6 @@ jobs:
 
       - name: Install Dependencies
         run: pipenv sync --dev
-
-      - name: Run doctest
-        run: pipenv run python3 -m doctest lib/husky_musher/utils/*
 
       - name: Run unittest
         run: pipenv run python -m unittest lib/husky_musher/tests/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,4 +35,7 @@ jobs:
         run: pipenv sync --dev
 
       - name: Run unittest
-        run: pipenv run python -m unittest lib/husky_musher/tests/*
+        run: pipenv run python -m unittest lib/husky_musher/tests/* -v
+
+      - name: Run doctest
+        run: pipenv run python -m doctest lib/husky_musher/utils/* -v

--- a/README.md
+++ b/README.md
@@ -37,13 +37,16 @@ The required environment variables are:
 ## Tests
 Run doctests on the utils functions with:
 ```sh
-pipenv run python3 -m doctest lib/husky_musher/utils/*
+FLASK_ENV=development envdir <path to redcap envdir> pipenv run python3 -m doctest lib/husky_musher/utils/*
 ```
 
 Run unit tests with:
 ```sh
-pipenv run python -m unittest lib/husky_musher/tests/*
+FLASK_ENV=development envdir <path to redcap envdir> pipenv run python -m unittest lib/husky_musher/tests/*
 ```
+
+Note that although running the tests accesses the redcap envdir (specifically `REDCAP_API_URL`), it does not use these variables to connect to a project,
+so dummy environment variables can be used if desired.
 
 
 ## Attributions

--- a/bin/dump-cache
+++ b/bin/dump-cache
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
+import sys
+from pathlib import Path
 from id3c.json import dump_ndjson
-from husky_musher.utils.redcap import CACHE
 
-dump_ndjson(map(CACHE.get, CACHE))
+# by default, python does not include this path in its search path,
+# so we have to explicitly insert the path to the musher directory
+# in order to import it successfully
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+from husky_musher.utils.redcap import LazyObjects
+
+dump_ndjson(map(LazyObjects.get_cache().get, LazyObjects.get_cache()))

--- a/bin/preheat-cache
+++ b/bin/preheat-cache
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-from husky_musher.utils.redcap import CACHE, PROJECT, redcap_registration_complete
+import sys
+from pathlib import Path
+
+# by default, python does not include this path in its search path,
+# so we have to explicitly insert the path to the musher directory
+# in order to import it successfully
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+from husky_musher.utils.redcap import LazyObjects, redcap_registration_complete
 
 # XXX FIXME: This is copied from fetch_participant() and thus could drift out
 # of sync.  I don't anticipate we'll use this script more than once or twice,
@@ -15,7 +22,7 @@ fields = [
     'enrollment_questionnaire_complete',
 ]
 
-records = PROJECT.records(raw = True, fields = fields, filter = '[netid] <> ""')
+records = LazyObjects.get_project().records(raw = True, fields = fields, filter = '[netid] <> ""')
 print(f"{len(records):7,} records fetched")
 
 n = 0
@@ -24,8 +31,8 @@ for record in records:
     netid = record.get("netid")
 
     if netid and redcap_registration_complete(record):
-        CACHE[netid] = record
+        LazyObjects.get_cache()[netid] = record
         n += 1
 
 print(f"{n:7,} records cached")
-print(f"{len(CACHE):7,} records in cache")
+print(f"{len(LazyObjects.get_cache()):7,} records in cache")

--- a/lib/husky_musher/app.py
+++ b/lib/husky_musher/app.py
@@ -17,8 +17,9 @@ configure_logger(logging_config_file)
 
 app = Flask(__name__)
 
-# Load the RedCap project from utils that is associated with our environment
-LazyProject.load_project()
+# Load the RedCap project and Fanout cache from within lazy container in utils
+LazyObjects.get_project()
+LazyObjects.get_cache()
 
 # Setup Prometheus metrics collector.
 if "prometheus_multiproc_dir" in os.environ:

--- a/lib/husky_musher/app.py
+++ b/lib/husky_musher/app.py
@@ -17,6 +17,8 @@ configure_logger(logging_config_file)
 
 app = Flask(__name__)
 
+# Load the RedCap project from utils that is associated with our environment
+LazyProject.load_project()
 
 # Setup Prometheus metrics collector.
 if "prometheus_multiproc_dir" in os.environ:

--- a/lib/husky_musher/tests/lead_dawgs.py
+++ b/lib/husky_musher/tests/lead_dawgs.py
@@ -20,7 +20,7 @@ class TestingProject():
 
 
 # inject the test project into the redcap utils' lazy loader
-redcap_utils.LazyProject.redcap = TestingProject()
+redcap_utils.LazyObjects.redcap_project = TestingProject()
 
 
 class TestLeadDawgs0(unittest.TestCase):
@@ -53,7 +53,7 @@ class TestLeadDawgs0(unittest.TestCase):
         self.assertFalse(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_kiosk_registration_link(self):
-        PROJECT = redcap_utils.LazyProject.load_project()
+        PROJECT = redcap_utils.LazyObjects.get_project()
         self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
@@ -113,7 +113,7 @@ class TestLeadDawgs1(unittest.TestCase):
         self.assertTrue(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_kiosk_registration_link(self):
-        PROJECT = redcap_utils.LazyProject.load_project()
+        PROJECT = redcap_utils.LazyObjects.get_project()
         self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
@@ -176,7 +176,7 @@ class TestLeadDawgs2(unittest.TestCase):
         self.assertTrue(self.instances['incomplete_kr'] is not None)
 
     def test_kiosk_registration_link(self):
-        PROJECT = redcap_utils.LazyProject.load_project()
+        PROJECT = redcap_utils.LazyObjects.get_project()
         self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
@@ -236,7 +236,7 @@ class TestLeadDawgs3(unittest.TestCase):
         self.assertFalse(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_kiosk_registration_link(self):
-        PROJECT = redcap_utils.LazyProject.load_project()
+        PROJECT = redcap_utils.LazyObjects.get_project()
         self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
@@ -296,7 +296,7 @@ class TestLeadDawgs4(unittest.TestCase):
         self.assertFalse(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_kiosk_registration_link(self):
-        PROJECT = redcap_utils.LazyProject.load_project()
+        PROJECT = redcap_utils.LazyObjects.get_project()
         self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
@@ -350,7 +350,7 @@ class TestLeadDawgs5(unittest.TestCase):
         self.assertTrue(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_kiosk_registration_link(self):
-        PROJECT = redcap_utils.LazyProject.load_project()
+        PROJECT = redcap_utils.LazyObjects.get_project()
         self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"

--- a/lib/husky_musher/tests/lead_dawgs.py
+++ b/lib/husky_musher/tests/lead_dawgs.py
@@ -3,11 +3,25 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from utils.redcap import *
+import utils.redcap as redcap_utils
 
 REDCAP_RECORD = {
     'record_id': '-1',
 }
+
+# Dummy RedCap project for testing purposes
+class TestingProject():
+    def __init__(self) -> None:
+        self.base_url = "https://dummy.redcap.org/"
+        self.api_url = "https://dummy.redcap.org/api"
+        self.id = -1
+        self.redcap_version = -1
+        self.api_token = "testing"
+
+
+# inject the test project into the redcap utils' lazy loader
+redcap_utils.LazyProject.redcap = TestingProject()
+
 
 class TestLeadDawgs0(unittest.TestCase):
     """
@@ -16,12 +30,12 @@ class TestLeadDawgs0(unittest.TestCase):
     def setUp(self):
         self.recent_encounters = []
         self.instances = dict()
-        self.instances['target'] = target = max_instance_testing_triggered(self.recent_encounters)
-        self.instances['complete_tos'] = max_instance('test_order_survey',
+        self.instances['target'] = target = redcap_utils.max_instance_testing_triggered(self.recent_encounters)
+        self.instances['complete_tos'] = redcap_utils.max_instance('test_order_survey',
             self.recent_encounters, since=target)
-        self.instances['complete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['complete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target)
-        self.instances['incomplete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['incomplete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target, complete=False)
 
     def test_instances(self):
@@ -33,17 +47,18 @@ class TestLeadDawgs0(unittest.TestCase):
         })
 
     def test_need_to_create_new_td_for_today(self):
-        self.assertTrue(need_to_create_new_td_for_today(self.instances))
+        self.assertTrue(redcap_utils.need_to_create_new_td_for_today(self.instances))
 
     def test_need_to_create_new_kr_instance(self):
-        self.assertFalse(need_to_create_new_kr_instance(self.instances))
+        self.assertFalse(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_kiosk_registration_link(self):
-        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+        PROJECT = redcap_utils.LazyProject.load_project()
+        self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
-            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
-            f"&instance={get_todays_repeat_instance()}"
+            f"&arm=encounter_arm_1&event_id={redcap_utils.EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&instance={redcap_utils.get_todays_repeat_instance()}"
         )
 
 
@@ -75,12 +90,12 @@ class TestLeadDawgs1(unittest.TestCase):
             }
         ]
         self.instances = dict()
-        self.instances['target'] = target = max_instance_testing_triggered(self.recent_encounters)
-        self.instances['complete_tos'] = max_instance('test_order_survey',
+        self.instances['target'] = target = redcap_utils.max_instance_testing_triggered(self.recent_encounters)
+        self.instances['complete_tos'] = redcap_utils.max_instance('test_order_survey',
             self.recent_encounters, since=target)
-        self.instances['complete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['complete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target)
-        self.instances['incomplete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['incomplete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target, complete=False)
 
     def test_instances(self):
@@ -92,16 +107,17 @@ class TestLeadDawgs1(unittest.TestCase):
         })
 
     def test_need_to_create_new_td_for_today(self):
-        self.assertFalse(need_to_create_new_td_for_today(self.instances))
+        self.assertFalse(redcap_utils.need_to_create_new_td_for_today(self.instances))
 
     def test_need_to_create_new_kr_instance(self):
-        self.assertTrue(need_to_create_new_kr_instance(self.instances))
+        self.assertTrue(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_kiosk_registration_link(self):
-        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+        PROJECT = redcap_utils.LazyProject.load_project()
+        self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
-            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&arm=encounter_arm_1&event_id={redcap_utils.EVENT_ID}&page=kiosk_registration_4c7f"
             f"&instance={self.instances['target']}"
         )
 
@@ -134,12 +150,12 @@ class TestLeadDawgs2(unittest.TestCase):
             }
         ]
         self.instances = dict()
-        self.instances['target'] = target = max_instance_testing_triggered(self.recent_encounters)
-        self.instances['complete_tos'] = max_instance('test_order_survey',
+        self.instances['target'] = target = redcap_utils.max_instance_testing_triggered(self.recent_encounters)
+        self.instances['complete_tos'] = redcap_utils.max_instance('test_order_survey',
             self.recent_encounters, since=target)
-        self.instances['complete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['complete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target)
-        self.instances['incomplete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['incomplete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target, complete=False)
 
     def test_instances(self):
@@ -151,19 +167,20 @@ class TestLeadDawgs2(unittest.TestCase):
         })
 
     def test_need_to_create_new_td_for_today(self):
-        self.assertFalse(need_to_create_new_td_for_today(self.instances))
+        self.assertFalse(redcap_utils.need_to_create_new_td_for_today(self.instances))
 
     def test_need_to_create_new_kr_instance(self):
-        self.assertFalse(need_to_create_new_kr_instance(self.instances))
+        self.assertFalse(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_incomplete_kr_instance_is_not_none(self):
         self.assertTrue(self.instances['incomplete_kr'] is not None)
 
     def test_kiosk_registration_link(self):
-        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+        PROJECT = redcap_utils.LazyProject.load_project()
+        self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
-            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&arm=encounter_arm_1&event_id={redcap_utils.EVENT_ID}&page=kiosk_registration_4c7f"
             f"&instance={self.instances['incomplete_kr']}"
         )
 
@@ -196,12 +213,12 @@ class TestLeadDawgs3(unittest.TestCase):
             }
         ]
         self.instances = dict()
-        self.instances['target'] = target = max_instance_testing_triggered(self.recent_encounters)
-        self.instances['complete_tos'] = max_instance('test_order_survey',
+        self.instances['target'] = target = redcap_utils.max_instance_testing_triggered(self.recent_encounters)
+        self.instances['complete_tos'] = redcap_utils.max_instance('test_order_survey',
             self.recent_encounters, since=target)
-        self.instances['complete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['complete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target)
-        self.instances['incomplete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['incomplete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target, complete=False)
 
     def test_instances(self):
@@ -213,17 +230,18 @@ class TestLeadDawgs3(unittest.TestCase):
         })
 
     def test_need_to_create_new_td_for_today(self):
-        self.assertTrue(need_to_create_new_td_for_today(self.instances))
+        self.assertTrue(redcap_utils.need_to_create_new_td_for_today(self.instances))
 
     def test_need_to_create_new_kr_instance(self):
-        self.assertFalse(need_to_create_new_kr_instance(self.instances))
+        self.assertFalse(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_kiosk_registration_link(self):
-        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+        PROJECT = redcap_utils.LazyProject.load_project()
+        self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
-            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
-            f"&instance={get_todays_repeat_instance()}"
+            f"&arm=encounter_arm_1&event_id={redcap_utils.EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&instance={redcap_utils.get_todays_repeat_instance()}"
         )
 
 
@@ -235,19 +253,19 @@ class TestLeadDawgs4(unittest.TestCase):
     def setUp(self):
         self.recent_encounters = [
             {
-                'redcap_repeat_instance': str(one_week_ago() + 1),
+                'redcap_repeat_instance': str(redcap_utils.one_week_ago() + 1),
                 'testing_determination_complete': '2',
                 'testing_trigger': 'No',
                 'test_order_survey_complete': '',
                 'kiosk_registration_4c7f_complete': ''
             }, {
-                'redcap_repeat_instance': str(one_week_ago() + 2),
+                'redcap_repeat_instance': str(redcap_utils.one_week_ago() + 2),
                 'testing_determination_complete': '',
                 'testing_trigger': '',
                 'test_order_survey_complete': '',
                 'kiosk_registration_4c7f_complete': '2'
             }, {
-                'redcap_repeat_instance': str(one_week_ago() + 3),
+                'redcap_repeat_instance': str(redcap_utils.one_week_ago() + 3),
                 'testing_determination_complete': '',
                 'testing_trigger': '',
                 'test_order_survey_complete': '2',
@@ -255,34 +273,35 @@ class TestLeadDawgs4(unittest.TestCase):
             }
         ]
         self.instances = dict()
-        self.instances['target'] = target = max_instance_testing_triggered(self.recent_encounters)
-        self.instances['complete_tos'] = max_instance('test_order_survey',
+        self.instances['target'] = target = redcap_utils.max_instance_testing_triggered(self.recent_encounters)
+        self.instances['complete_tos'] = redcap_utils.max_instance('test_order_survey',
             self.recent_encounters, since=target)
-        self.instances['complete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['complete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target)
-        self.instances['incomplete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['incomplete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target, complete=False)
 
     def test_instances(self):
         self.assertEqual(self.instances, {
             'target': None,
-            'complete_tos': one_week_ago() + 3,
-            'complete_kr': one_week_ago() + 2,
+            'complete_tos': redcap_utils.one_week_ago() + 3,
+            'complete_kr': redcap_utils.one_week_ago() + 2,
             'incomplete_kr': None,
         })
 
     def test_need_to_create_new_td_for_today(self):
-        self.assertTrue(need_to_create_new_td_for_today(self.instances))
+        self.assertTrue(redcap_utils.need_to_create_new_td_for_today(self.instances))
 
     def test_need_to_create_new_kr_instance(self):
-        self.assertFalse(need_to_create_new_kr_instance(self.instances))
+        self.assertFalse(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_kiosk_registration_link(self):
-        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+        PROJECT = redcap_utils.LazyProject.load_project()
+        self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
-            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
-            f"&instance={get_todays_repeat_instance()}"
+            f"&arm=encounter_arm_1&event_id={redcap_utils.EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&instance={redcap_utils.get_todays_repeat_instance()}"
         )
 
 
@@ -294,13 +313,13 @@ class TestLeadDawgs5(unittest.TestCase):
     def setUp(self):
         self.recent_encounters = [
             {
-                'redcap_repeat_instance': str(one_week_ago() + 1),
+                'redcap_repeat_instance': str(redcap_utils.one_week_ago() + 1),
                 'testing_determination_complete': '2',
                 'testing_trigger': 'Yes',
                 'test_order_survey_complete': '2',
                 'kiosk_registration_4c7f_complete': ''
             }, {
-                'redcap_repeat_instance': str(one_week_ago() + 2),
+                'redcap_repeat_instance': str(redcap_utils.one_week_ago() + 2),
                 'testing_determination_complete': '2',
                 'testing_trigger': 'Yes',
                 'test_order_survey_complete': '',
@@ -308,32 +327,33 @@ class TestLeadDawgs5(unittest.TestCase):
             },
         ]
         self.instances = dict()
-        self.instances['target'] = target = max_instance_testing_triggered(self.recent_encounters)
-        self.instances['complete_tos'] = max_instance('test_order_survey',
+        self.instances['target'] = target = redcap_utils.max_instance_testing_triggered(self.recent_encounters)
+        self.instances['complete_tos'] = redcap_utils.max_instance('test_order_survey',
             self.recent_encounters, since=target)
-        self.instances['complete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['complete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target)
-        self.instances['incomplete_kr'] = max_instance('kiosk_registration_4c7f',
+        self.instances['incomplete_kr'] = redcap_utils.max_instance('kiosk_registration_4c7f',
             self.recent_encounters, since=target, complete=False)
 
     def test_instances(self):
         self.assertEqual(self.instances, {
-            'target': one_week_ago() + 2,
+            'target': redcap_utils.one_week_ago() + 2,
             'complete_tos': None,
             'complete_kr': None,
             'incomplete_kr': None,
         })
 
     def test_need_to_create_new_td_for_today(self):
-        self.assertFalse(need_to_create_new_td_for_today(self.instances))
+        self.assertFalse(redcap_utils.need_to_create_new_td_for_today(self.instances))
 
     def test_need_to_create_new_kr_instance(self):
-        self.assertTrue(need_to_create_new_kr_instance(self.instances))
+        self.assertTrue(redcap_utils.need_to_create_new_kr_instance(self.instances))
 
     def test_kiosk_registration_link(self):
-        self.assertEqual(kiosk_registration_link(REDCAP_RECORD, self.instances),
+        PROJECT = redcap_utils.LazyProject.load_project()
+        self.assertEqual(redcap_utils.kiosk_registration_link(REDCAP_RECORD, self.instances),
             f"{PROJECT.base_url}redcap_v{PROJECT.redcap_version}/DataEntry/index.php?"
             f"pid={PROJECT.id}&id={REDCAP_RECORD['record_id']}"
-            f"&arm=encounter_arm_1&event_id={EVENT_ID}&page=kiosk_registration_4c7f"
-            f"&instance={one_week_ago() + 2}"
+            f"&arm=encounter_arm_1&event_id={redcap_utils.EVENT_ID}&page=kiosk_registration_4c7f"
+            f"&instance={redcap_utils.one_week_ago() + 2}"
         )

--- a/lib/husky_musher/utils/redcap.py
+++ b/lib/husky_musher/utils/redcap.py
@@ -26,24 +26,23 @@ else:
     EVENT_ID = 129
     STUDY_START_DATE = datetime(2021, 9, 9) # Date testing opened on new HCT redcap server
 
+# Load the RedCap project lazily. Initialize a container project so that
+# if this file is run from the test suite, the test suite can inject a
+# dummy project into the container before a RedCap project is initialized.
+# If instead this file is imported by the Flask application, it will
+# load the connection to the RedCap project as determined by our
+# environment configuration
+class ProjectContainer:
+    def __init__(self) -> None:
+        self.redcap = None
 
-# TODO - Since creating PROJECT has side effects (network requests), we should
-# # probably define it lazily (e.g. with `global PROJECT` and then assigning it
-# the Project object `if not PROJECT`.
-#
-# During development, I could not get unit tests to run without running into a
-# NameError saying PROJECT is not defined.
-# Tom left some helpful feedback in a PR comment:
-# > I suspect this is because the tests as-is access PROJECT directly but it was
-# > only initialized with a value on the first call to generate_redcap_link().
-# > The references to PROJECT in the tests are resolved before that first call
-# > happens, so PROJECT was unset.
-#
-# It would be nice to investigate further how to define PROJECT lazily in
-# coordination with unit tests.
-#
-# -kfay, 23 October 2020
-PROJECT = Project(REDCAP_API_URL, PROJECT_ID)
+    def load_project(self):
+        """load the desired redcap project if no project has been set"""
+        if not self.redcap:
+            self.redcap = Project(REDCAP_API_URL, PROJECT_ID)
+        return self.redcap
+
+LazyProject = ProjectContainer()
 
 # These values in REDCap must be imported as their raw codes, not their label,
 # else we get a 400 Client Error from REDCap when POSTing.
@@ -96,7 +95,7 @@ def fetch_participant(user_info: dict) -> Optional[Dict[str, str]]:
             ]
 
             data = {
-                'token': PROJECT.api_token,
+                'token': LazyProject.redcap.api_token,
                 'content': 'record',
                 'format': 'json',
                 'type': 'flat',
@@ -111,7 +110,7 @@ def fetch_participant(user_info: dict) -> Optional[Dict[str, str]]:
                 'returnFormat': 'json'
             }
 
-            response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
+            response = requests.post(LazyProject.redcap.api_url, data=data, timeout=TIMEOUT)
             response.raise_for_status()
 
             assert 'application/json' in response.headers.get('Content-Type'), "Unexpected content type " \
@@ -144,7 +143,7 @@ def register_participant(user_info: dict) -> str:
     # real record ID.
     records = [{**user_info, 'record_id': 'record ID cannot be blank'}]
     data = {
-        'token': PROJECT.api_token,
+        'token': LazyProject.redcap.api_token,
         'content': 'record',
         'format': 'json',
         'type': 'flat',
@@ -154,9 +153,9 @@ def register_participant(user_info: dict) -> str:
         'returnContent': 'ids',
         'returnFormat': 'json'
     }
-    response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
+    response = requests.post(LazyProject.redcap.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
-    
+
     assert 'application/json' in response.headers.get('Content-Type'), "Unexpected content type " \
         f"≪{response.headers.get('Content-Type')}≫, expected ≪application/json≫."
 
@@ -175,7 +174,7 @@ def generate_survey_link(record_id: str, event: str, instrument: str, instance: 
     Will include the repeat *instance* if provided.
     """
     data = {
-        'token': PROJECT.api_token,
+        'token': LazyProject.redcap.api_token,
         'content': 'surveyLink',
         'format': 'json',
         'instrument': instrument,
@@ -187,7 +186,7 @@ def generate_survey_link(record_id: str, event: str, instrument: str, instance: 
     if instance:
         data['repeat_instance'] = str(instance)
 
-    response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
+    response = requests.post(LazyProject.redcap.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
 
     assert 'text/html' in response.headers.get('Content-Type'), "Unexpected content type " \
@@ -260,7 +259,7 @@ def fetch_encounter_events_past_week(redcap_record: dict) -> List[dict]:
     # useful to us, because all instances associated with a record are returned,
     # regardless of the instance's creation or modification date.
     data = {
-        'token': PROJECT.api_token,
+        'token': LazyProject.redcap.api_token,
         'content': 'record',
         'format': 'json',
         'type': 'flat',
@@ -276,7 +275,7 @@ def fetch_encounter_events_past_week(redcap_record: dict) -> List[dict]:
         'returnFormat': 'json'
     }
 
-    response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
+    response = requests.post(LazyProject.redcap.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
 
     assert 'application/json' in response.headers.get('Content-Type'), "Unexpected content type " \
@@ -493,7 +492,7 @@ def create_new_testing_determination(redcap_record: dict):
     }]
 
     data = {
-        'token': PROJECT.api_token,
+        'token': LazyProject.redcap.api_token,
         'content': 'record',
         'format': 'json',
         'type': 'flat',
@@ -504,7 +503,7 @@ def create_new_testing_determination(redcap_record: dict):
         'returnFormat': 'json'
     }
 
-    response = requests.post(PROJECT.api_url, data=data, timeout=TIMEOUT)
+    response = requests.post(LazyProject.redcap.api_url, data=data, timeout=TIMEOUT)
     response.raise_for_status()
 
     assert 'application/json' in response.headers.get('Content-Type'), "Unexpected content type " \
@@ -643,8 +642,11 @@ def kiosk_registration_link(redcap_record: dict, instances: Dict[str, int]) -> s
     incomplete_kr_instance = instances['incomplete_kr']
 
     if need_to_create_new_td_for_today(instances):
-        # Create TD instance based on # of days since project start.
-        create_new_testing_determination(redcap_record)
+        # Create TD instance based on # of days since project start, but
+        # only if this is not the testing project
+        if LazyProject.redcap.id != -1:
+            create_new_testing_determination(redcap_record)
+
         instance = get_todays_repeat_instance()
 
     elif need_to_create_new_kr_instance(instances):
@@ -665,7 +667,7 @@ def generate_redcap_link(redcap_record: dict, instance: int):
     Kiosk Registration form for the record's given REDCap repeat *instance*.
     """
     query = urlencode({
-        'pid': PROJECT.id,
+        'pid': LazyProject.redcap.id,
         'id': redcap_record['record_id'],
         'arm': 'encounter_arm_1',
         'event_id': EVENT_ID,
@@ -673,5 +675,5 @@ def generate_redcap_link(redcap_record: dict, instance: int):
         'instance': instance,
     })
 
-    return urljoin(PROJECT.base_url,
-        f"redcap_v{PROJECT.redcap_version}/DataEntry/index.php?{query}")
+    return urljoin(LazyProject.redcap.base_url,
+        f"redcap_v{LazyProject.redcap.redcap_version}/DataEntry/index.php?{query}")


### PR DESCRIPTION
Adds Github Actions for the Husky Musher Repo. Because of an issue running `doctests` while using the `fanout cache`, this change initially only adds actions for running the unittest suite of this repository. Also ensures that the test suite no longer needs to hit the RedCap API while running tests by lazily loading the RedCap project only as needed and injecting a test project where the real one would have been loaded before.

The Lazy Loading changes were implemented as follows: I created a project container, which is initialized to have its field `redcap_project = None`. This way the RedCap project is no longer initialized as soon as this file is imported by the testsuite. The testsuite then sets the RedCap project to be a dummy project, complete with the fields `redcap.py` expects a RedCap project to have. When this file is not initialized by the test suite, the `redcap_project` field in container will remain unitialized. When functions in this file attempt to load the project for the first time, the project will first check to make sure it has been loaded, and if not, load the RedCap project as it would have before.

This logic flow allows us to avoid unnecessary calls to the RedCap API during testing, while still preserving the loading of the correct RedCap project in both the production and development Flask environment.