### PR TITLE
Adding gitignore files to function as allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/app.py
+!/Pipfile
+!/Pipfile.lock
+!/README.md
+!/logging.yaml
+
+# and these directories
+!/bin/
+!/lib/
+!/lib/husky_musher/
+!/notes/
+
+# and this nested file
+!/.github/
+!/.github/workflows/
+!/.github/workflows/ci.yaml

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,7 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/dump-cache
+!/preheat-cache

--- a/lib/husky_musher/.gitignore
+++ b/lib/husky_musher/.gitignore
@@ -1,0 +1,12 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/*.py
+
+# and these directories
+!/static/
+!/templates/
+!/tests/
+!/utils/

--- a/lib/husky_musher/static/.gitignore
+++ b/lib/husky_musher/static/.gitignore
@@ -1,0 +1,8 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/*.ico
+!/*.svg
+!/*.css

--- a/lib/husky_musher/templates/.gitignore
+++ b/lib/husky_musher/templates/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/*.html

--- a/lib/husky_musher/tests/.gitignore
+++ b/lib/husky_musher/tests/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/*.py

--- a/lib/husky_musher/utils/.gitignore
+++ b/lib/husky_musher/utils/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/*.py

--- a/notes/.gitignore
+++ b/notes/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/kiosk-flow.png


### PR DESCRIPTION
Adding `.gitignore` files to exclude everything up front, with
exceptions for files and folder that should be included. This is to
reduce the chance of pushing any files unintentionally.