### PR TITLE
Disable LeadDawgs Route

### DIFF
--- a/lib/husky_musher/templates/base.html
+++ b/lib/husky_musher/templates/base.html
@@ -1,8 +1,9 @@
 <!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{% block title %}{% endblock %} - Lead Dawgs</title>
 <link rel="shortcut icon" type="image/jpg" href="{{ url_for('static', filename='favicon.ico') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+<!-- To render the LeadDawgs link, uncomment the block below.
+<title>{% block title %}{% endblock %} - Lead Dawgs</title>
 <nav>
   <a href={{ url_for('.lead_dawgs') }}>
     <img id="paw-prints"
@@ -11,6 +12,7 @@
       Lead Dawgs
   </a>
 </nav>
+-->
 <header>
   <h1>
     Husky Coronavirus Testing


### PR DESCRIPTION
HCT Y3 will no longer be using kiosk tests, so LeadDawgs is no longer needed. This change
adds a decorator to disable a route, rendering a 404 error for the route instead. If we
ever require LeadDawgs again, simply removing the `@route_disabled` decorator will allow
the route to be accessed again.