### PR TITLE
Turn on Structured Logging for Musher

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -1,19 +1,16 @@
 ---
 version: 1
 
-# Leave the new structured log handler turned off until we figure out log storage destination.
-# Currently written as a file handler for structured logging proof of concept.
+root:
+  handlers:
+    - fileHandler
 
-# root:
-#   handlers:
-#     - fileHandler
-
-# handlers:
-#   fileHandler:
-#     class: logging.FileHandler
-#     level: INFO
-#     formatter: json
-#     filename: logs/husky_musher.log # Placeholder until we figure out log store
+handlers:
+  fileHandler:
+    class: logging.FileHandler
+    level: INFO
+    formatter: json
+    filename: /var/log/uwsgi/app/husky_musher.log
 
 formatters:
   json:


### PR DESCRIPTION
This change turns on Musher structured logs and sends them to a log destination to
be scraped up by Grafana. We are already picking up logs from the location
`/var/log/uwsgi/app/husky-musher.log`, so will send them there. I don't see those
files as having been updated since september of last year, so should be good to send
there without worrying about messing up any current logging processes.