### PR TITLE
Revert "Turn on Structured Logging for Musher"

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -1,16 +1,19 @@
 ---
 version: 1
 
-root:
-  handlers:
-    - fileHandler
+# Leave the new structured log handler turned off until we figure out log storage destination.
+# Currently written as a file handler for structured logging proof of concept.
 
-handlers:
-  fileHandler:
-    class: logging.FileHandler
-    level: INFO
-    formatter: json
-    filename: /var/log/uwsgi/app/husky_musher.log
+# root:
+#   handlers:
+#     - fileHandler
+
+# handlers:
+#   fileHandler:
+#     class: logging.FileHandler
+#     level: INFO
+#     formatter: json
+#     filename: logs/husky_musher.log # Placeholder until we figure out log store
 
 formatters:
   json:


### PR DESCRIPTION
Reverts seattleflu/husky-musher#21. Logs could not be written to this location, so Musher failed to start. Currently have a new location in #22 .